### PR TITLE
商品詳細表示機能

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,5 +1,5 @@
 class ItemsController < ApplicationController
-  before_action :move_to_index, except: [:index]
+  before_action :move_to_index, except: [:index, :show]
   def new
     @item = Item.new
   end
@@ -13,6 +13,17 @@ class ItemsController < ApplicationController
     end
   end
 
+<<<<<<< Updated upstream
+=======
+  def index
+    @items = Item.all.order('id DESC')
+  end
+
+  def show
+    @items = Item.find(params[:id])
+  end
+
+>>>>>>> Stashed changes
   private
 
   def move_to_index

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,5 +1,7 @@
 class ItemsController < ApplicationController
   before_action :move_to_index, except: [:index, :show]
+  before_action :set_item, only: [:show]
+  
   def new
     @item = Item.new
   end
@@ -18,7 +20,6 @@ class ItemsController < ApplicationController
   end
 
   def show
-    @items = Item.find(params[:id])
   end
 
   private
@@ -29,5 +30,9 @@ class ItemsController < ApplicationController
 
   def create_params
     params.require(:item).permit(:image, :name, :story, :category_id, :status_id, :delivery_fee_id, :shipping_address_id, :delivery_date_id, :price).merge(user_id: current_user.id)
+  end
+
+  def set_item
+    @items = Item.find(params[:id])
   end
 end

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -13,8 +13,6 @@ class ItemsController < ApplicationController
     end
   end
 
-<<<<<<< Updated upstream
-=======
   def index
     @items = Item.all.order('id DESC')
   end
@@ -23,7 +21,6 @@ class ItemsController < ApplicationController
     @items = Item.find(params[:id])
   end
 
->>>>>>> Stashed changes
   private
 
   def move_to_index

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -13,5 +13,6 @@ class Item < ApplicationRecord
   validates :price, length: { in: 300...9999999, message: 'Out of setting range' }, format: { with: /\A[0-9]+\z/, message: 'Half-width number' }
 =======
   validates :price, length: { maximum: 9_999_999, minimum: 300, message: 'Out of setting range' }, format: { with: /\A[0-9]+\z/, message: 'Half-width number' }
+>>>>>>> Stashed changes
   validates :category_id, :status_id, :delivery_fee_id, :shipping_address_id, :delivery_date_id, numericality: { other_than: 1, message: 'Select' }
 end

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -9,10 +9,6 @@ class Item < ApplicationRecord
   has_one_attached :image
 
   validates :image, :name, :story, :category_id, :status_id, :delivery_fee_id, :shipping_address_id, :delivery_date_id, :price, :user_id, presence: true
-<<<<<<< Updated upstream
-  validates :price, length: { in: 300...9999999, message: 'Out of setting range' }, format: { with: /\A[0-9]+\z/, message: 'Half-width number' }
-=======
   validates :price, length: { maximum: 9_999_999, minimum: 300, message: 'Out of setting range' }, format: { with: /\A[0-9]+\z/, message: 'Half-width number' }
->>>>>>> Stashed changes
   validates :category_id, :status_id, :delivery_fee_id, :shipping_address_id, :delivery_date_id, numericality: { other_than: 1, message: 'Select' }
 end

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -9,6 +9,9 @@ class Item < ApplicationRecord
   has_one_attached :image
 
   validates :image, :name, :story, :category_id, :status_id, :delivery_fee_id, :shipping_address_id, :delivery_date_id, :price, :user_id, presence: true
+<<<<<<< Updated upstream
   validates :price, length: { in: 300...9999999, message: 'Out of setting range' }, format: { with: /\A[0-9]+\z/, message: 'Half-width number' }
+=======
+  validates :price, length: { maximum: 9_999_999, minimum: 300, message: 'Out of setting range' }, format: { with: /\A[0-9]+\z/, message: 'Half-width number' }
   validates :category_id, :status_id, :delivery_fee_id, :shipping_address_id, :delivery_date_id, numericality: { other_than: 1, message: 'Select' }
 end

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -125,53 +125,31 @@
     <h2 class='title'>ピックアップカテゴリー</h2>
     <%= link_to '新規投稿商品', "#", class: "subtitle" %>
     <ul class='item-lists'>
-
-      <%# 商品のインスタンス変数になにか入っている場合、中身のすべてを展開できるようにしましょう %>
-<<<<<<< Updated upstream
+       <%# 商品のインスタンス変数になにか入っている場合、中身のすべてを展開できるようにしましょう %>
       <li class='list'>
-        <%= link_to "#" do %>
-        <div class='item-img-content'>
-          <%= image_tag "item-sample.png", class: "item-img" %>
-=======
-    <li class='list'>
-      <% @items.each do |item| %>
-        <%= link_to item_path(item.id) do %>
-         <div class='item-img-content'>
-           <%= image_tag item.image, class: "item-img"  if item.image.attached? %>
->>>>>>> Stashed changes
-
-            <%# 商品が売れていればsold outの表示 %>
-            <div class='sold-out'>
-              <span>Sold Out!!</span>
-            </div>
-           <%# //商品が売れていればsold outの表示 %>
-
-<<<<<<< Updated upstream
-        </div>
-        <div class='item-info'>
-          <h3 class='item-name'>
-            <%= "商品名" %>
-          </h3>
-          <div class='item-price'>
-            <span><%= "販売価格" %>円<br>(税込み)</span>
-            <div class='star-btn'>
-              <%= image_tag "star.png", class:"star-icon" %>
-              <span class='star-count'>0</span>
-=======
-          </div>
-          <div class='item-info'>
-            <h3 class='item-name'>
-              <%= item.name %>
-            </h3>
-            <div class='item-price'>
-              <span><%= item.price %>円<br>(税込み)</span>
-              <div class='star-btn'>
-                <%= image_tag "star.png", class:"star-icon" %>
-                <span class='star-count'>0</span>
+        <% @items.each do |item| %>
+          <%= link_to item_path(item.id) do %>
+          <div class='item-img-content'>
+            <%= image_tag item.image, class: "item-img"  if item.image.attached? %>
+              <%# 商品が売れていればsold outの表示 %>
+              <div class='sold-out'>
+                <span>Sold Out!!</span>
               </div>
->>>>>>> Stashed changes
+              <%# //商品が売れていればsold outの表示 %>
             </div>
-          </div>
+            <div class='item-info'>
+              <h3 class='item-name'>
+                <%= item.name %>
+              </h3>
+              <div class='item-price'>
+                <span><%= item.price %>円<br>(税込み)</span>
+                <div class='star-btn'>
+                  <%= image_tag "star.png", class:"star-icon" %>
+                  <span class='star-count'>0</span>
+                </div>
+              </div>
+            </div>
+          <% end %>
         <% end %>
       </li>
       <%# //商品のインスタンス変数になにか入っている場合、中身のすべてを展開できるようにしましょう %>
@@ -203,6 +181,8 @@
 </div>
 <div class='purchase-btn'>
   <span class='purchase-btn-text'>出品する</span>
-  <%= link_to image_tag("camera.png", size: '185x50' ,class: "purchase-btn-icon"), "items_new_path" %>
+  <%= link_to new_item_path do %> 
+    <%= image_tag 'camera.png', size: '185x50' ,class: "purchase-btn-icon" %>
+  <% end %>
 </div>
 <%= render "shared/footer" %>

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -127,17 +127,26 @@
     <ul class='item-lists'>
 
       <%# 商品のインスタンス変数になにか入っている場合、中身のすべてを展開できるようにしましょう %>
+<<<<<<< Updated upstream
       <li class='list'>
         <%= link_to "#" do %>
         <div class='item-img-content'>
           <%= image_tag "item-sample.png", class: "item-img" %>
+=======
+    <li class='list'>
+      <% @items.each do |item| %>
+        <%= link_to item_path(item.id) do %>
+         <div class='item-img-content'>
+           <%= image_tag item.image, class: "item-img"  if item.image.attached? %>
+>>>>>>> Stashed changes
 
-          <%# 商品が売れていればsold outの表示 %>
-          <div class='sold-out'>
-            <span>Sold Out!!</span>
-          </div>
-          <%# //商品が売れていればsold outの表示 %>
+            <%# 商品が売れていればsold outの表示 %>
+            <div class='sold-out'>
+              <span>Sold Out!!</span>
+            </div>
+           <%# //商品が売れていればsold outの表示 %>
 
+<<<<<<< Updated upstream
         </div>
         <div class='item-info'>
           <h3 class='item-name'>
@@ -148,9 +157,21 @@
             <div class='star-btn'>
               <%= image_tag "star.png", class:"star-icon" %>
               <span class='star-count'>0</span>
+=======
+          </div>
+          <div class='item-info'>
+            <h3 class='item-name'>
+              <%= item.name %>
+            </h3>
+            <div class='item-price'>
+              <span><%= item.price %>円<br>(税込み)</span>
+              <div class='star-btn'>
+                <%= image_tag "star.png", class:"star-icon" %>
+                <span class='star-count'>0</span>
+              </div>
+>>>>>>> Stashed changes
             </div>
           </div>
-        </div>
         <% end %>
       </li>
       <%# //商品のインスタンス変数になにか入っている場合、中身のすべてを展開できるようにしましょう %>

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -4,10 +4,10 @@
 <div class="item-show">
   <div class="item-box">
     <h2 class="name">
-      <%= "商品名" %>
+      <%= @items.name %>
     </h2>
     <div class='item-img-content'>
-      <%= image_tag "item-sample.png" ,class:"item-box-img" %>
+      <%= image_tag @items.image ,class:"item-box-img" %>
       <%# 商品が売れている場合は、sold outの表示をしましょう。 %>
       <div class='sold-out'>
         <span>Sold Out!!</span>
@@ -16,7 +16,7 @@
     </div>
     <div class="item-price-box">
       <span class="item-price">
-        ¥ 999,999,999
+        <%= @items.price %>
       </span>
       <span class="item-postage">
         (税込) 送料込み
@@ -24,47 +24,47 @@
     </div>
 
     <%# ログインしているユーザと出品しているユーザが同一人物である時、商品の編集と削除を表示にしましょう%>
-
-    <%= link_to '商品の編集', "#", method: :get, class: "item-red-btn" %>
-    <p class='or-text'>or</p>
-    <%= link_to '削除', "#", method: :delete, class:'item-destroy' %>
-
-    <%# 商品が売れていない場合はこちらを表示しましょう %>
-    <%= link_to '購入画面に進む', "#" ,class:"item-red-btn"%>
-    <%# //商品が売れていない場合はこちらを表示しましょう %>
-
+   <% if current_user == @items.user %> 
+     <%= link_to '商品の編集', "#", method: :get, class: "item-red-btn" %>
+     <p class='or-text'>or</p>
+     <%= link_to '削除', "#", method: :delete, class:'item-destroy' %>
+    <% else %>
+      <%# 商品が売れていない場合はこちらを表示しましょう %>
+      <%= link_to '購入画面に進む', "#" ,class:"item-red-btn"%>
+      <%# //商品が売れていない場合はこちらを表示しましょう %>
+    <% end %>
     <%# // ログインしているユーザと出品しているユーザが同一人物である時、商品の編集と削除を表示にしましょう %>
 
     <div class="item-explain-box">
-      <span><%= "商品説明" %></span>
+      <span><%= @items.story %></span>
     </div>
     <table class="detail-table">
-      <tbody>
-        <tr>
-          <th class="detail-item">出品者</th>
-          <td class="detail-value"><%= "出品者名" %></td>
-        </tr>
-        <tr>
-          <th class="detail-item">カテゴリー</th>
-          <td class="detail-value"><%= "カテゴリー名" %></td>
-        </tr>
-        <tr>
-          <th class="detail-item">商品の状態</th>
-          <td class="detail-value"><%= "商品の状態" %></td>
-        </tr>
-        <tr>
-          <th class="detail-item">配送料の負担</th>
-          <td class="detail-value"><%= "発送料の負担" %></td>
-        </tr>
-        <tr>
-          <th class="detail-item">発送元の地域</th>
-          <td class="detail-value"><%= "発送元の地域" %></td>
-        </tr>
-        <tr>
-          <th class="detail-item">発送日の目安</th>
-          <td class="detail-value"><%= "発送日の目安" %></td>
-        </tr>
-      </tbody>
+        <tbody>
+          <tr>
+            <th class="detail-item">出品者</th>
+            <td class="detail-value"><%= @items.user.nickname %></td>
+          </tr>
+          <tr>
+            <th class="detail-item">カテゴリー</th>
+            <td class="detail-value"><%= @items.category.name %></td>
+          </tr>
+          <tr>
+            <th class="detail-item">商品の状態</th>
+            <td class="detail-value"><%= @items.status.name %></td>
+          </tr>
+          <tr>
+            <th class="detail-item">配送料の負担</th>
+            <td class="detail-value"><%= @items.delivery_fee.name %></td>
+          </tr>
+          <tr>
+            <th class="detail-item">発送元の地域</th>
+            <td class="detail-value"><%= @items.shipping_address.name %></td>
+          </tr>
+          <tr>
+            <th class="detail-item">発送日の目安</th>
+            <td class="detail-value"><%= @items.delivery_date.name %></td>
+          </tr>
+        </tbody>
     </table>
     <div class="option">
       <div class="favorite-btn">

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -6,16 +6,13 @@
   <%= csrf_meta_tags %>
   <%= csp_meta_tag %>
   <script type="text/javascript" src="https://js.pay.jp/v1/">
-	});
-
-}
   </script>
   <%= stylesheet_link_tag 'application', media: 'all'%>
   <%= javascript_pack_tag 'application' %>
 </head>
 
-
+<body>
   <%= yield %>
-  
+</body>
 
 </html>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,14 +1,6 @@
 Rails.application.routes.draw do
-  root to: 'items#index'
-  get '/sing_in', to: 'sessions#new'
-  get '/sign_up', to: 'registrations#new'
   devise_for :users
-<<<<<<< Updated upstream
-  get 'items_new_path', to: 'items#new'
-  resources :items, only: :create
-  # dbのルーティングとモデルとビューの紐付け周り　保存させる
-=======
+  root to: 'items#index'
   resources :items, only: [:new, :create, :index, :show]
->>>>>>> Stashed changes
   # For details on the DSL available within this file, see https://guides.rubyonrails.org/routing.html
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,8 +3,12 @@ Rails.application.routes.draw do
   get '/sing_in', to: 'sessions#new'
   get '/sign_up', to: 'registrations#new'
   devise_for :users
+<<<<<<< Updated upstream
   get 'items_new_path', to: 'items#new'
   resources :items, only: :create
   # dbのルーティングとモデルとビューの紐付け周り　保存させる
+=======
+  resources :items, only: [:new, :create, :index, :show]
+>>>>>>> Stashed changes
   # For details on the DSL available within this file, see https://guides.rubyonrails.org/routing.html
 end

--- a/spec/models/item_spec.rb
+++ b/spec/models/item_spec.rb
@@ -17,7 +17,6 @@ describe Item do
         @item.price = '1234'
         expect(@item.user).to be_valid
       end
-      
     end
 
     context '商品登録がうまくいかないとき' do
@@ -65,12 +64,12 @@ describe Item do
       it 'priceが300未満であれば登録できない' do
         @item.price = '299'
         @item.valid?
-        expect(@item.errors.full_messages).to  include('Price Out of setting range')
+        expect(@item.errors.full_messages).to include('Price Out of setting range')
       end
       it 'priceが10000000以上であれば登録できない' do
         @item.price = '10000000'
         @item.valid?
-        expect(@item.errors.full_messages).to  include('Price Out of setting range')
+        expect(@item.errors.full_messages).to include('Price Out of setting range')
       end
     end
   end


### PR DESCRIPTION
##what
商品詳細画面表示機能を実装しました

**before_actionを用いてアクションをメソッド化した**

##why
ログインしているユーザ、していないユーザー、出品者とは関係ないユーザーが適切に商品詳細ページに訪れることができるようにするため。

**可読性を向上させるため**

ログインユーザーかつ出品者の商品詳細ページ
[![Image from Gyazo](https://i.gyazo.com/9fe990d358a97523ab66e27d1bede0fa.jpg)](https://gyazo.com/9fe990d358a97523ab66e27d1bede0fa)
非ログインユーザーの商品詳細ページ
[![Image from Gyazo](https://i.gyazo.com/85adfff20c3026387759c7c83270e9de.jpg)](https://gyazo.com/85adfff20c3026387759c7c83270e9de)
非出品ユーザーの商品詳細ページ
[![Image from Gyazo](https://i.gyazo.com/facb8e4ac3ecb52b92762a2241dfa994.jpg)](https://gyazo.com/facb8e4ac3ecb52b92762a2241dfa994)
商品情報ページの情報
[![Image from Gyazo](https://i.gyazo.com/f644b23bc7545695dec71abb023b7549.png)](https://gyazo.com/f644b23bc7545695dec71abb023b7549)